### PR TITLE
Add canvas management tools for Tambo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,8 @@
         "react-markdown": "^10.1.0",
         "react-syntax-highlighter": "^15.6.1",
         "recharts": "^2.15.3",
-        "sanitize-html": "^2.14.0"
+        "sanitize-html": "^2.14.0",
+        "zustand": "^5.0.4"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -10044,6 +10045,35 @@
       "license": "ISC",
       "peerDependencies": {
         "zod": "^3.24.1"
+      }
+    },
+    "node_modules/zustand": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.4.tgz",
+      "integrity": "sha512-39VFTN5InDtMd28ZhjLyuTnlytDr9HfwO512Ai4I8ZABCoyAj4F1+sr7sD1jP/+p7k77Iko0Pb5NhgBFDCX0kQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
       }
     },
     "node_modules/zwitch": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "react-markdown": "^10.1.0",
     "react-syntax-highlighter": "^15.6.1",
     "recharts": "^2.15.3",
-    "sanitize-html": "^2.14.0"
+    "sanitize-html": "^2.14.0",
+    "zustand": "^5.0.4"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { ComponentsCanvas } from "@/components/ui/components-canvas";
 import { MessageThreadFull } from "@/components/ui/message-thread-full";
-import { components } from "@/lib/tambo";
+import { components, tools } from "@/lib/tambo";
 import { Suggestion, TamboProvider } from "@tambo-ai/react";
 import { TamboMcpProvider } from "@tambo-ai/react/mcp";
 
@@ -58,6 +58,7 @@ export default function Home() {
       <TamboProvider
         apiKey={process.env.NEXT_PUBLIC_TAMBO_API_KEY!}
         components={components}
+        tools={tools}
       >
         <TamboMcpProvider mcpServers={mcpServers}>
           <div className="flex h-full overflow-hidden">

--- a/src/lib/canvas-storage.ts
+++ b/src/lib/canvas-storage.ts
@@ -1,0 +1,396 @@
+/**
+ * canvas-storage.ts
+ * Central library for canvas storage operations and data types
+ */
+import { create } from "zustand";
+import { createJSONStorage, persist } from "zustand/middleware";
+
+// Canvas data model types
+export interface CanvasComponent {
+  componentId: string;
+  _componentType: string;
+  _inCanvas?: boolean;
+  canvasId?: string;
+  [key: string]: unknown;
+}
+
+export interface Canvas {
+  id: string;
+  name: string;
+  components: CanvasComponent[];
+}
+
+export interface CanvasState {
+  canvases: Canvas[];
+  activeCanvasId: string | null;
+  pendingOperations: Set<string>;
+  // Actions
+  getCanvases: () => Canvas[];
+  getCanvas: (id: string) => Canvas | undefined;
+  getComponents: (canvasId: string) => CanvasComponent[];
+  createCanvas: (name?: string) => Canvas;
+  updateCanvas: (id: string, name: string) => Canvas | null;
+  removeCanvas: (id: string) => void;
+  setActiveCanvas: (id: string | null) => void;
+  clearCanvas: (id: string) => void;
+  addComponent: (canvasId: string, component: CanvasComponent) => void;
+  updateComponent: (
+    canvasId: string,
+    componentId: string,
+    props: Record<string, unknown>
+  ) => CanvasComponent | null;
+  removeComponent: (canvasId: string, componentId: string) => void;
+  moveComponent: (
+    sourceCanvasId: string,
+    targetCanvasId: string,
+    componentId: string
+  ) => CanvasComponent | null;
+  reorderComponent: (
+    canvasId: string,
+    componentId: string,
+    newIndex: number
+  ) => void;
+}
+
+// Generate a unique ID for components or canvases
+export const generateId = () =>
+  `id-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+
+// Create the store with persistence
+export const useCanvasStore = create<CanvasState>()(
+  persist(
+    (set, get) => ({
+      canvases: [],
+      activeCanvasId: null,
+      pendingOperations: new Set<string>(),
+
+      // Get all canvases
+      getCanvases: () => get().canvases,
+
+      // Get a specific canvas by ID
+      getCanvas: (id: string) => get().canvases.find((c) => c.id === id),
+
+      // Get components for a specific canvas
+      getComponents: (canvasId: string) => {
+        const canvas = get().canvases.find((c) => c.id === canvasId);
+        return canvas?.components || [];
+      },
+
+      // Create a new canvas
+      createCanvas: (name?: string) => {
+        const id = generateId();
+        const canvases = get().canvases;
+        const canvasName = name || `New Canvas ${canvases.length + 1}`;
+        const newCanvas: Canvas = { id, name: canvasName, components: [] };
+
+        set((state) => ({
+          canvases: [...state.canvases, newCanvas],
+          activeCanvasId: state.activeCanvasId || id,
+        }));
+
+        return newCanvas;
+      },
+
+      // Update canvas name
+      updateCanvas: (id: string, name: string) => {
+        const updatedName = name.trim();
+        if (!updatedName) return null;
+
+        let updatedCanvas: Canvas | null = null;
+
+        set((state) => {
+          const updatedCanvases = state.canvases.map((c) => {
+            if (c.id === id) {
+              updatedCanvas = { ...c, name: updatedName };
+              return updatedCanvas;
+            }
+            return c;
+          });
+
+          return { canvases: updatedCanvases };
+        });
+
+        return updatedCanvas;
+      },
+
+      // Remove a canvas
+      removeCanvas: (id: string) => {
+        set((state) => {
+          const updatedCanvases = state.canvases.filter((c) => c.id !== id);
+          let activeId = state.activeCanvasId;
+
+          // If we're removing the active canvas, select another one
+          if (activeId === id) {
+            activeId = updatedCanvases[0]?.id || null;
+          }
+
+          return {
+            canvases: updatedCanvases,
+            activeCanvasId: activeId,
+          };
+        });
+      },
+
+      // Set the active canvas
+      setActiveCanvas: (id: string | null) => {
+        set({ activeCanvasId: id });
+      },
+
+      // Clear all components from a canvas
+      clearCanvas: (id: string) => {
+        set((state) => ({
+          canvases: state.canvases.map((c) =>
+            c.id === id ? { ...c, components: [] } : c
+          ),
+        }));
+      },
+
+      // Add a component to a canvas
+      addComponent: (canvasId: string, componentProps: CanvasComponent) => {
+        const componentId = componentProps.componentId || generateId();
+
+        // Check for duplicate operations
+        const operationKey = `add-${componentId}-${canvasId}`;
+        const pendingOps = get().pendingOperations;
+
+        if (pendingOps.has(operationKey)) {
+          console.log(`[CANVAS] Skipping duplicate operation: ${operationKey}`);
+          return;
+        }
+
+        // Mark operation as pending
+        pendingOps.add(operationKey);
+        set({ pendingOperations: new Set(pendingOps) });
+
+        // Update state
+        set((state) => {
+          // Check if component already exists
+          const targetCanvas = state.canvases.find((c) => c.id === canvasId);
+          if (
+            targetCanvas &&
+            targetCanvas.components.some((c) => c.componentId === componentId)
+          ) {
+            console.log(
+              `[CANVAS] Component ${componentId} already exists in canvas ${canvasId}`
+            );
+            // Remove operation from pending after 100ms
+            setTimeout(() => {
+              const ops = get().pendingOperations;
+              ops.delete(operationKey);
+              set({ pendingOperations: new Set(ops) });
+            }, 100);
+            return state;
+          }
+
+          const updatedCanvases = state.canvases.map((c) =>
+            c.id === canvasId
+              ? {
+                  ...c,
+                  components: [
+                    ...c.components,
+                    {
+                      ...componentProps,
+                      componentId,
+                      _inCanvas: true,
+                      canvasId,
+                    },
+                  ],
+                }
+              : c
+          );
+
+          // Remove operation from pending after 100ms
+          setTimeout(() => {
+            const ops = get().pendingOperations;
+            ops.delete(operationKey);
+            set({ pendingOperations: new Set(ops) });
+          }, 100);
+
+          return { canvases: updatedCanvases };
+        });
+      },
+
+      // Update a component's props
+      updateComponent: (
+        canvasId: string,
+        componentId: string,
+        props: Record<string, unknown>
+      ) => {
+        let updatedComponent: CanvasComponent | null = null;
+
+        set((state) => {
+          const updatedCanvases = state.canvases.map((c) => {
+            if (c.id !== canvasId) return c;
+
+            const updatedComponents = c.components.map((comp) => {
+              if (comp.componentId !== componentId) return comp;
+
+              updatedComponent = { ...comp, ...props };
+              return updatedComponent;
+            });
+
+            return { ...c, components: updatedComponents };
+          });
+
+          return { canvases: updatedCanvases };
+        });
+
+        return updatedComponent;
+      },
+
+      // Remove a component from a canvas
+      removeComponent: (canvasId: string, componentId: string) => {
+        set((state) => ({
+          canvases: state.canvases.map((c) =>
+            c.id === canvasId
+              ? {
+                  ...c,
+                  components: c.components.filter(
+                    (comp) => comp.componentId !== componentId
+                  ),
+                }
+              : c
+          ),
+        }));
+      },
+
+      // Move a component from one canvas to another
+      moveComponent: (
+        sourceCanvasId: string,
+        targetCanvasId: string,
+        componentId: string
+      ) => {
+        // Skip if source and target are the same
+        if (sourceCanvasId === targetCanvasId) return null;
+
+        const operationKey = `move-${componentId}-${sourceCanvasId}-${targetCanvasId}`;
+        const pendingOps = get().pendingOperations;
+
+        if (pendingOps.has(operationKey)) {
+          console.log(
+            `[CANVAS] Skipping duplicate move operation: ${operationKey}`
+          );
+          return null;
+        }
+
+        // Mark operation as pending
+        pendingOps.add(operationKey);
+        set({ pendingOperations: new Set(pendingOps) });
+
+        let movedComponent: CanvasComponent | null = null;
+
+        set((state) => {
+          // Find component in source canvas
+          const sourceCanvas = state.canvases.find(
+            (c) => c.id === sourceCanvasId
+          );
+          if (!sourceCanvas) return state;
+
+          const component = sourceCanvas.components.find(
+            (c) => c.componentId === componentId
+          );
+          if (!component) return state;
+
+          // Check if component already exists in target
+          const targetCanvas = state.canvases.find(
+            (c) => c.id === targetCanvasId
+          );
+          if (
+            targetCanvas &&
+            targetCanvas.components.some((c) => c.componentId === componentId)
+          ) {
+            console.log(
+              `[CANVAS] Component ${componentId} already exists in target canvas ${targetCanvasId}`
+            );
+            return state;
+          }
+
+          // Create updated component
+          movedComponent = {
+            ...component,
+            canvasId: targetCanvasId,
+          };
+
+          // Remove from source and add to target
+          const updatedCanvases = state.canvases.map((c) => {
+            if (c.id === sourceCanvasId) {
+              return {
+                ...c,
+                components: c.components.filter(
+                  (comp) => comp.componentId !== componentId
+                ),
+              };
+            }
+            if (c.id === targetCanvasId) {
+              return {
+                ...c,
+                components: [...c.components, movedComponent!],
+              };
+            }
+            return c;
+          });
+
+          // Remove operation from pending after 100ms
+          setTimeout(() => {
+            const ops = get().pendingOperations;
+            ops.delete(operationKey);
+            set({ pendingOperations: new Set(ops) });
+          }, 100);
+
+          return { canvases: updatedCanvases };
+        });
+
+        return movedComponent;
+      },
+
+      // Reorder a component within a canvas
+      reorderComponent: (
+        canvasId: string,
+        componentId: string,
+        newIndex: number
+      ) => {
+        set((state) => {
+          const updatedCanvases = state.canvases.map((c) => {
+            if (c.id !== canvasId) return c;
+
+            // Find the component
+            const componentIndex = c.components.findIndex(
+              (comp) => comp.componentId === componentId
+            );
+            if (componentIndex === -1) return c;
+
+            // Create a new components array
+            const newComponents = [...c.components];
+
+            // Remove component from current position
+            const [component] = newComponents.splice(componentIndex, 1);
+
+            // Clamp newIndex to array bounds
+            const boundedIndex = Math.max(
+              0,
+              Math.min(newComponents.length, newIndex)
+            );
+
+            // Insert at new position
+            newComponents.splice(boundedIndex, 0, component);
+
+            return {
+              ...c,
+              components: newComponents,
+            };
+          });
+
+          return { canvases: updatedCanvases };
+        });
+      },
+    }),
+    {
+      name: "tambo-canvas-storage",
+      storage: createJSONStorage(() => localStorage),
+      partialize: (state) => ({
+        canvases: state.canvases,
+        activeCanvasId: state.activeCanvasId,
+      }),
+    }
+  )
+);

--- a/src/lib/tambo.ts
+++ b/src/lib/tambo.ts
@@ -12,6 +12,7 @@ import { DataCard, dataCardSchema } from "@/components/ui/card-data";
 import { Graph, graphSchema } from "@/components/ui/graph";
 import type { TamboComponent } from "@tambo-ai/react";
 import { TamboTool } from "@tambo-ai/react";
+import { canvasTools } from "@/tools/canvas-tools";
 
 /**
  * tools
@@ -24,6 +25,7 @@ import { TamboTool } from "@tambo-ai/react";
 export const tools: TamboTool[] = [
   // Set the MCP tools https://localhost:3000/mcp-config
   // Add non MCP tools here
+  ...canvasTools,
 ];
 
 /**

--- a/src/tools/canvas-tools.ts
+++ b/src/tools/canvas-tools.ts
@@ -1,0 +1,146 @@
+
+import { TamboTool } from "@tambo-ai/react";
+import { z } from "zod";
+
+interface CanvasComponent {
+  componentId: string;
+  _componentType?: string;
+  [key: string]: unknown;
+}
+
+interface Canvas {
+  id: string;
+  name: string;
+  components: CanvasComponent[];
+}
+
+const STORAGE_KEY = "tambo_canvases";
+
+function loadCanvases(): { canvases: Canvas[]; activeCanvasId?: string } {
+  if (typeof localStorage === "undefined") return { canvases: [] };
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed.canvases)) {
+        return { canvases: parsed.canvases, activeCanvasId: parsed.activeCanvasId };
+      }
+    }
+  } catch (err) {
+    console.error("Failed to load canvases", err);
+  }
+  return { canvases: [] };
+}
+
+function saveCanvases(canvases: Canvas[], activeCanvasId?: string) {
+  if (typeof localStorage === "undefined") return;
+  try {
+    const payload = JSON.stringify({ canvases, activeCanvasId });
+    localStorage.setItem(STORAGE_KEY, payload);
+  } catch (err) {
+    console.error("Failed to save canvases", err);
+  }
+}
+
+const generateId = () =>
+  `id-${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
+
+/** Create a new canvas */
+export const createCanvasTool: TamboTool = {
+  name: "createCanvas",
+  description: "Create a new canvas and return the id",
+  tool: (name?: string) => {
+    const { canvases, activeCanvasId } = loadCanvases();
+    const id = generateId();
+    const canvasName = name || `New Canvas ${canvases.length + 1}`;
+    const newCanvas: Canvas = { id, name: canvasName, components: [] };
+    const updated = [...canvases, newCanvas];
+    saveCanvases(updated, activeCanvasId);
+    return newCanvas;
+  },
+  toolSchema: z
+    .function()
+    .args(z.string().optional())
+    .returns(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        components: z.array(z.any()),
+      }),
+    ),
+};
+
+/** Get all canvases */
+export const getCanvasesTool: TamboTool = {
+  name: "getCanvases",
+  description: "Get the list of canvases",
+  tool: () => {
+    const { canvases } = loadCanvases();
+    return canvases;
+  },
+  toolSchema: z.function().args().returns(z.array(z.any())),
+};
+
+/** Update canvas name */
+export const updateCanvasTool: TamboTool = {
+  name: "updateCanvas",
+  description: "Update a canvas name given its id",
+  tool: (id: string, name: string) => {
+    const { canvases, activeCanvasId } = loadCanvases();
+    const updated = canvases.map((c) => (c.id === id ? { ...c, name } : c));
+    saveCanvases(updated, activeCanvasId);
+    return updated.find((c) => c.id === id) ?? null;
+  },
+  toolSchema: z
+    .function()
+    .args(z.string(), z.string())
+    .returns(z.any()),
+};
+
+/** Get components for a canvas */
+export const getCanvasComponentsTool: TamboTool = {
+  name: "getCanvasComponents",
+  description: "Get all components for a canvas",
+  tool: (id: string) => {
+    const { canvases } = loadCanvases();
+    return canvases.find((c) => c.id === id)?.components || [];
+  },
+  toolSchema: z.function().args(z.string()).returns(z.array(z.any())),
+};
+
+/** Update a component's props in a canvas */
+export const updateCanvasComponentTool: TamboTool = {
+  name: "updateCanvasComponent",
+  description: "Update component props in a canvas",
+  tool: (canvasId: string, componentId: string, props: Record<string, unknown>) => {
+    const { canvases, activeCanvasId } = loadCanvases();
+    const updated = canvases.map((c) => {
+      if (c.id !== canvasId) return c;
+      return {
+        ...c,
+        components: c.components.map((comp) =>
+          comp.componentId === componentId ? { ...comp, ...props } : comp,
+        ),
+      };
+    });
+    saveCanvases(updated, activeCanvasId);
+    return (
+      updated
+        .find((c) => c.id === canvasId)
+        ?.components.find((comp) => comp.componentId === componentId) || null
+    );
+  },
+  toolSchema: z
+    .function()
+    .args(z.string(), z.string(), z.record(z.any()))
+    .returns(z.any()),
+};
+
+export const canvasTools = [
+  createCanvasTool,
+  getCanvasesTool,
+  updateCanvasTool,
+  getCanvasComponentsTool,
+  updateCanvasComponentTool,
+];
+


### PR DESCRIPTION
## Summary
- implement local canvas tools for create/read/update canvas data
- export canvas tools in tambo configuration

## Testing
- `npm run lint`
- `npm run build` *(fails: connect EHOSTUNREACH)*